### PR TITLE
Working deploy workflow

### DIFF
--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -11,13 +11,29 @@ on:
     branches: ["main"]
 
 jobs:
-  call-workflow:
-    uses: mbta/workflows/.github/workflows/deploy-ecs.yml@v4
-    with:
-      app-name: bye-bye-bye
-      environment: ${{ github.event.inputs.environment || 'dev' }}
-      allow-zero-desired: true
-    secrets:
-      aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
-      docker-repo: ${{ secrets.DOCKER_REPO }}
-      slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    environment: ${{ inputs.environment }}
+    concurrency: ${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mbta/actions/build-push-ecr@v2
+        id: build-push
+        with:
+          role-to-assume: ${{ secrets.aws-role-arn }}
+          docker-repo: ${{ secrets.docker-repo }}
+      - uses: mbta/actions/deploy-scheduled-ecs@v2
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          ecs-cluster: bye-bye-bye
+          ecs-service: bye-bye-bye-${{ inputs.environment }}
+          ecs-task-definition: bye-bye-bye-${{ inputs.environment }}
+          docker-tag: ${{ steps.build-push.outputs.docker-tag }}
+      - uses: mbta/actions/notify-slack-deploy@v2
+        if: ${{ !cancelled() }}
+        with:
+          webhook-url: ${{ secrets.slack-webhook }}
+          job-status: ${{ job.status }}

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -23,8 +23,8 @@ jobs:
       - uses: mbta/actions/build-push-ecr@v2
         id: build-push
         with:
-          role-to-assume: ${{ secrets.aws-role-arn }}
-          docker-repo: ${{ secrets.docker-repo }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          docker-repo: ${{ secrets.DOCKER_REPO }}
       - uses: mbta/actions/deploy-scheduled-ecs@v2
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
@@ -35,5 +35,5 @@ jobs:
       - uses: mbta/actions/notify-slack-deploy@v2
         if: ${{ !cancelled() }}
         with:
-          webhook-url: ${{ secrets.slack-webhook }}
+          webhook-url: ${{ secrets.SLACK_WEBHOOK }}
           job-status: ${{ job.status }}

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -12,10 +12,11 @@ on:
 
 jobs:
   call-workflow:
-    uses: mbta/workflows/.github/workflows/deploy-ecs.yml@v2
+    uses: mbta/workflows/.github/workflows/deploy-ecs.yml@v4
     with:
       app-name: bye-bye-bye
       environment: ${{ github.event.inputs.environment || 'dev' }}
+      allow-zero-desired: true
     secrets:
       aws-role-arn: ${{ secrets.AWS_ROLE_ARN }}
       docker-repo: ${{ secrets.DOCKER_REPO }}


### PR DESCRIPTION
Asana ticket: [🚫 Deploy Cancellations service](https://app.asana.com/1/15492006741476/project/584764604969369/task/1209170494596792)

It turns out that we actually need to use the `deploy-scheduled-ecs` action, following the example of the various LAMP tasks that we based the Bye Bye Bye setup on.