### PR TITLE
chore: Add start_date to feed

### DIFF
--- a/lib/bye_bye_bye.ex
+++ b/lib/bye_bye_bye.ex
@@ -39,7 +39,7 @@ defmodule ByeByeBye do
           |> tap(fn schedules ->
             Logger.info("Generated cancellation entities affected_trips=#{map_size(schedules)}")
           end)
-          |> Enum.map(&Utils.build_cancellation_entity(&1, now_unix))
+          |> Enum.map(&Utils.build_cancellation_entity(&1, now))
 
         message = %FeedMessage{
           header: %FeedHeader{

--- a/lib/bye_bye_bye/utils.ex
+++ b/lib/bye_bye_bye/utils.ex
@@ -40,7 +40,7 @@ defmodule ByeByeBye.Utils do
     * `{trip_id, schedule}` - A tuple containing:
       * `trip_id` - The ID of the cancelled trip
       * `schedule` - List of schedule entries for the trip
-    * `now` - Current timestamp as Unix time in seconds
+    * `now` - Current timestamp as DateTime
 
   ## Returns
   A `TransitRealtime.FeedEntity` struct with:
@@ -53,11 +53,12 @@ defmodule ByeByeBye.Utils do
     %FeedEntity{
       id: trip_id,
       trip_update: %TripUpdate{
-        timestamp: now,
+        timestamp: DateTime.to_unix(now),
         trip: %TripDescriptor{
           trip_id: trip_id,
           route_id: route_id,
-          schedule_relationship: "CANCELED"
+          schedule_relationship: "CANCELED",
+          start_date: Calendar.strftime(now, "%Y%m%d")
         },
         stop_time_update: Enum.map(schedule, &schedule_to_stop_time_update/1)
       }

--- a/test/bye_bye_bye/utils_test.exs
+++ b/test/bye_bye_bye/utils_test.exs
@@ -101,7 +101,7 @@ defmodule ByeByeBye.UtilsTest do
   describe "build_cancellation_entity/2" do
     test "creates a feed entity with proper cancellation details" do
       trip_id = "123"
-      now = 1_706_000_000
+      now = ~U[2024-01-23 08:53:20Z]
 
       schedule = [
         %{
@@ -131,7 +131,8 @@ defmodule ByeByeBye.UtilsTest do
                  trip: %TripDescriptor{
                    trip_id: "123",
                    route_id: "Red",
-                   schedule_relationship: "CANCELED"
+                   schedule_relationship: "CANCELED",
+                   start_date: "20240123"
                  },
                  stop_time_update: [
                    %StopTimeUpdate{

--- a/test/bye_bye_bye/utils_test.exs
+++ b/test/bye_bye_bye/utils_test.exs
@@ -102,6 +102,7 @@ defmodule ByeByeBye.UtilsTest do
     test "creates a feed entity with proper cancellation details" do
       trip_id = "123"
       now = ~U[2024-01-23 08:53:20Z]
+      start_date = Calendar.strftime(now, "%Y%m%d")
 
       schedule = [
         %{
@@ -132,7 +133,7 @@ defmodule ByeByeBye.UtilsTest do
                    trip_id: "123",
                    route_id: "Red",
                    schedule_relationship: "CANCELED",
-                   start_date: "20240123"
+                   start_date: ^start_date
                  },
                  stop_time_update: [
                    %StopTimeUpdate{


### PR DESCRIPTION
Asana task: [[extra] 🚫 Add start_date to feed published by ByeByeBye](https://app.asana.com/1/15492006741476/project/1203810889612417/task/1209562587669649?focus=true)

Swiftly requires `start_date` in the feed. They can't parse the feed without it. I _think_ we can just use `now`, but please do correctly me if that doesn't seem right.