### PR TITLE
fix: time zone and midnight-3 am handled in start_date

### DIFF
--- a/lib/bye_bye_bye/utils.ex
+++ b/lib/bye_bye_bye/utils.ex
@@ -50,6 +50,8 @@ defmodule ByeByeBye.Utils do
   def build_cancellation_entity({trip_id, schedule}, now) do
     route_id = schedule |> List.first() |> get_in(["relationships", "route", "data", "id"])
 
+    start_date = now |> service_day() |> Calendar.strftime("%Y%m%d")
+
     %FeedEntity{
       id: trip_id,
       trip_update: %TripUpdate{
@@ -58,7 +60,7 @@ defmodule ByeByeBye.Utils do
           trip_id: trip_id,
           route_id: route_id,
           schedule_relationship: "CANCELED",
-          start_date: Calendar.strftime(now, "%Y%m%d")
+          start_date: start_date
         },
         stop_time_update: Enum.map(schedule, &schedule_to_stop_time_update/1)
       }

--- a/test/bye_bye_bye/utils_test.exs
+++ b/test/bye_bye_bye/utils_test.exs
@@ -152,6 +152,24 @@ defmodule ByeByeBye.UtilsTest do
                }
              } = result
     end
+
+    test "start_date accounts for time zone, midnight-3 am as previous day's schedule" do
+      trip_id = "123"
+      # 2:53 AM in America/New_York
+      now = ~U[2024-01-24 07:53:20Z]
+
+      schedule = []
+
+      result = Utils.build_cancellation_entity({trip_id, schedule}, now)
+
+      assert %FeedEntity{
+               trip_update: %TripUpdate{
+                 trip: %TripDescriptor{
+                   start_date: "20240123"
+                 }
+               }
+             } = result
+    end
   end
 
   describe "get_affected_schedules/2" do


### PR DESCRIPTION
Asana task: [[bye-bye-bye] [extra] 🐛 CR cancellation for wrong date](https://app.asana.com/1/15492006741476/project/1204137169527258/task/1211410794959221?focus=true)

start_date in the output TripUpdate should account for the time zone, as well as the fact that midnight-3 am is considered the previous service date.

This fixes a problem where cancellations were issued for the following date because they were created after 8 pm Eastern.